### PR TITLE
Fixed typo in GitHub labels for dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,7 +67,7 @@ updates:
       prefix: "ci"
       include: "scope"
     labels:
-      - "⚙️github actions"
+      - "⚙️ github actions"
       - "dependencies"
     groups:
       # Group GitHub Actions updates


### PR DESCRIPTION
## Description

`dependabot.yml` label assignment had a typo resulting in workflow failing to recognize the appropriate labels to assign to the PR. Any missing labels have been created, and any typos have been corrected.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Post-Merge Checklist

*To be completed after merging:*

- [x] Delete feature branch
- [x] Update local main branch
- [x] Monitor for any issues in production use
- [x] Update project board/issues if applicable

---

**Note to Contributors:**
- Please ensure all checkboxes are completed before requesting review
- Feel free to delete sections that don't apply to your PR
- If you need help with any of these requirements, please ask in the PR comments

**Note to Reviewers:**
- Please provide constructive feedback
- Check that the PR follows our [Contributing Guidelines](../CONTRIBUTING.md)
- Consider the impact on existing users
- Test the changes locally if possible
